### PR TITLE
fix: Re-enable Snyk report upload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,11 @@ jobs:
           image: franky1/tesseract:${{ inputs.TAG }}
           args: --file=Dockerfile --sarif-file-output=snyk.sarif
 
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
+
       - name: Login to DockerHub
         uses: docker/login-action@v3.5.0
         with:


### PR DESCRIPTION
This commit re-enables the Snyk report upload in the docker.yml workflow by adding a step to upload the snyk.sarif file.