### PR TITLE
Remove SARIF upload step from Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,11 +68,6 @@ jobs:
           image: franky1/tesseract:${{ inputs.TAG }}
           args: --file=Dockerfile --sarif-file-output=snyk.sarif
 
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: snyk.sarif
-
       - name: Login to DockerHub
         uses: docker/login-action@v3.5.0
         with:


### PR DESCRIPTION
Removed the step to upload SARIF results to GitHub Code Scanning.